### PR TITLE
gnoframe render should inject a container using gnoMark id: gno-tag

### DIFF
--- a/static/gno-frame.js
+++ b/static/gno-frame.js
@@ -11,7 +11,7 @@ class GnoFrame extends HTMLElement {
                 height: 100%;
             }
             </style>
-            <div id="container">
+            <div id="gno-frame-container">
             <slot></slot>
             </div>
         `;
@@ -25,7 +25,10 @@ class GnoFrame extends HTMLElement {
             console.error('Error parsing JSON:', error);
             return;
         }
-        this.shadowRoot.querySelector('#container').innerHTML = `
+        const gnoFrameId = '#'+data.gnoFrame+"-container"
+        console.log(gnoFrameId);
+        /* Add your html here */
+        this.shadowRoot.querySelector(gnoFrameId).innerHTML = `
             <div>
             <h1>${data.name}</h1>
             <img src="${data.iconUrl}" alt="${data.name}">

--- a/static/index.html
+++ b/static/index.html
@@ -8,12 +8,25 @@
 </head>
 <body>
 
+<!--
+gnoFrame: "gno-frame" // identity declaration
+
+Users may extend this gno-frame to support your own logic by setting another value here
+the included gno-frame.js will only inject data into 'gno-frame' elements.
+
+So for example, if you want to use a different name, you can set it to "my-custom-frame" and then
+you would need to create a file named my-custom-frame.js and include it in this HTML file like so:
+<script src="my-custom-frame.js"/>
+
+and also set gnoFrame: "my-custom-frame" in the JSON object below
+-->
 <gno-frame>
 
 {
     "version": "0.1.0",
     "name": "GnoFrame",
     "iconUrl": "favicon-32x32.png",
+    "gnoFrame": "gno-frame",
     "homeUrl": "https://gno.land",
     "imageUrl": "android-chrome-512x512.png",
     "buttonTitle": "GnoFrame",
@@ -43,6 +56,7 @@
 }
 
 </gno-frame>
+<!-- Add your custom js in a file matching the tag-name example: <script src="my-custom-frame.js"/> -->
 <script src="gno-frame.js"/>
 </body>
 </html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,5 @@
+
+
+/*
+Common css for all gno-frames goes here
+ */


### PR DESCRIPTION
We consider that users can fork the default gno-tag template
by declaring a new my-custom-frame.js 
we expect it will be served via this repo.


Users who fork this whole dapp can expand the vocabulary of gno-frames by claiming their own name prefixes.

Ideally custom widgets are always thought of as optional enhancements on top of gno.land's defaule gnoweb support